### PR TITLE
Remove comma from formatted dates.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 const months = '["' + 'January,February,March,April,May,June,July,August,September,October,November,December'.split(',').join('","') + '"]';
 const days = '["' + 'Sunday,Monday,Tuesday,Wednesday,Thursday,Friday,Saturday'.split(',').join('","') + '"]';
 const formats = {
-	datetime: 'MMMM d, yyyy h:mm a',
-	date: 'MMMM d, yyyy'
+	datetime: 'MMMM d yyyy h:mm a',
+	date: 'MMMM d yyyy'
 };
 
 const compiledTemplates = {};

--- a/index.test.js
+++ b/index.test.js
@@ -3,7 +3,7 @@
 const proclaim = require('proclaim');
 const sinon = require('sinon/pkg/sinon');
 const ftDateFormat = require('./index');
-const window = typeof global === 'undefined' ? self : global; 
+const window = typeof global === 'undefined' ? self : global;
 
 describe('o-date', () => {
 
@@ -62,16 +62,16 @@ describe('o-date', () => {
 		});
 
 		it('returns a date if "date" is passed in as a second argument', () => {
-			proclaim.strictEqual(ftDateFormat.format(someDate, "date"), 'July 18, 2016');
+			proclaim.strictEqual(ftDateFormat.format(someDate, "date"), 'July 18 2016');
 		});
 
 		it('returns a datetime if "datetime" is passed in as a second argument', () => {
-			proclaim.strictEqual(ftDateFormat.format(someDate, "datetime"), 'July 18, 2016 11:12 pm');
+			proclaim.strictEqual(ftDateFormat.format(someDate, "datetime"), 'July 18 2016 11:12 pm');
 		});
 
 		it('doesnt zero pad single digit hours', () => {
 			const someDate = new Date("Mon Jul 18 2016 06:12:11");
-			proclaim.strictEqual(ftDateFormat.format(someDate, "datetime"), 'July 18, 2016 6:12 am');
+			proclaim.strictEqual(ftDateFormat.format(someDate, "datetime"), 'July 18 2016 6:12 am');
 		});
 
 		// This is a bit of a cop-out really as what we're testing here is ftDateFormat's
@@ -93,7 +93,7 @@ describe('o-date', () => {
 			const days = ['1st', '2nd', '3rd', '4th', '5th', '6th', '7th', '8th', '9th', '10th',
 				'11th', '12th', '13th', '14th', '15th', '16th', '17th', '18th', '19th', '20th',
 				'21st', '22nd', '23rd', '24th', '25th', '26th', '27th', '28th', '29th', '30th', '31st'];
-			
+
 			for (let i = 1; i <= days.length; i++) {
 				proclaim.strictEqual(ftDateFormat.format(new Date(2000, 0, i), 'do'), days[i - 1]);
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2050,7 +2050,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2071,12 +2072,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2091,17 +2094,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2218,7 +2224,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2230,6 +2237,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2244,6 +2252,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2251,12 +2260,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2275,6 +2286,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2355,7 +2367,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2367,6 +2380,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2452,7 +2466,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2488,6 +2503,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2507,6 +2523,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2550,12 +2567,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
The editorial styleguide states:

>FT style for writing dates is June 23 2016 (no commas, month/date/year),
>August 17, September 12 2012, November 25- December 5 2012, January 201