### PR TITLE
Updates package.json engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Financial-Times/ft-date-format#readme",
   "engines": {
-    "npm": "^7"
+    "npm": "^7 || ^8"
   },
   "volta": {
     "node": "14.16.1",


### PR DESCRIPTION
This brings the "engines" field in package.json in line with the rest of Origami in supporting npm 8