### PR TITLE
Add format string for editorial style

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,12 @@ const formatReplacementsMap = {
 	hh: 'pad2(((date.getHours() + 11) % 12) + 1)', // 03
 	H: 'date.getHours()', // 15
 	HH: 'pad2(date.getHours())', // 15
-	a: '(date.getHours() >= 12 ? "pm" : "am")' // pm
+	a: '(date.getHours() >= 12 ? "pm" : "am")', // pm
+	t: '`${(((date.getHours() + 11) % 12) + 1)}'
+		+ ':'
+		+ '${pad2(date.getMinutes())}'
+		+ '${date.getHours((date.getHours() >= 12 ? "pm" : "am"))'
+	+ '}`' // 3:05pm
 };
 
 const inSeconds = {

--- a/index.js
+++ b/index.js
@@ -34,8 +34,7 @@ const formatReplacementsMap = {
 	t: '`${(((date.getHours() + 11) % 12) + 1)}'
 		+ ':'
 		+ '${pad2(date.getMinutes())}'
-		+ '${date.getHours((date.getHours() >= 12 ? "pm" : "am"))'
-	+ '}`' // 3:05pm
+		+ '${date.getHours() >= 12 ? "pm" : "am"}`' // 3:05pm
 };
 
 const inSeconds = {

--- a/index.test.js
+++ b/index.test.js
@@ -116,6 +116,16 @@ describe('o-date', () => {
 			proclaim.strictEqual(ftDateFormat.format(someTimes["1pm"], 'hh'), '01');
 			proclaim.strictEqual(ftDateFormat.format(someTimes["11pm"], 'hh'), '11');
 		});
+		
+		it('returns an FT editorial-style time for `t` format', () => {
+			proclaim.strictEqual(ftDateFormat.format(someTimes["midnight"], 't'), '12:00am');
+			proclaim.strictEqual(ftDateFormat.format(someTimes["1am"], 't'), '1:00am');
+			proclaim.strictEqual(ftDateFormat.format(someTimes["10am"], 't'), '10:00am');
+			proclaim.strictEqual(ftDateFormat.format(someTimes["midday"], 't'), '12:00pm');
+			proclaim.strictEqual(ftDateFormat.format(someTimes["1pm"], 't'), '1:00pm');
+			proclaim.strictEqual(ftDateFormat.format(someTimes["11pm"], 't'), '11:00pm');
+			proclaim.strictEqual(ftDateFormat.format(someDate, 't'), '11:12am');
+		});
 
 		it('returns an unpadded 24hour clock value for `H` format', () => {
 			proclaim.strictEqual(ftDateFormat.format(someTimes["midnight"], 'H'), '0');

--- a/index.test.js
+++ b/index.test.js
@@ -118,7 +118,7 @@ describe('o-date', () => {
 		});
 		
 		it('returns an FT editorial-style time for `t` format', () => {
-			proclaim.strictEqual(ftDateFormat.format(someTimes["midnight"], 't'), '12:00am');
+			proclaim.strictEqual(ftDateFormat.format(someTimes["midnight"], 't'), '12:01am');
 			proclaim.strictEqual(ftDateFormat.format(someTimes["1am"], 't'), '1:00am');
 			proclaim.strictEqual(ftDateFormat.format(someTimes["10am"], 't'), '10:00am');
 			proclaim.strictEqual(ftDateFormat.format(someTimes["midday"], 't'), '12:00pm');

--- a/index.test.js
+++ b/index.test.js
@@ -124,7 +124,7 @@ describe('o-date', () => {
 			proclaim.strictEqual(ftDateFormat.format(someTimes["midday"], 't'), '12:00pm');
 			proclaim.strictEqual(ftDateFormat.format(someTimes["1pm"], 't'), '1:00pm');
 			proclaim.strictEqual(ftDateFormat.format(someTimes["11pm"], 't'), '11:00pm');
-			proclaim.strictEqual(ftDateFormat.format(someDate, 't'), '11:12am');
+			proclaim.strictEqual(ftDateFormat.format(someDate, 't'), '11:12pm');
 		});
 
 		it('returns an unpadded 24hour clock value for `H` format', () => {


### PR DESCRIPTION
t

Closes #134.

This is a breaking change because we don't know if people are using `t` literally in their format strings.